### PR TITLE
push beta version of plugin so we can use api endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cagov/wordpress-to-github": "^0.0.1"
+        "@cagov/wordpress-to-github": "^0.1.0"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/@cagov/wordpress-to-github": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@cagov/wordpress-to-github/-/wordpress-to-github-0.0.1.tgz",
-      "integrity": "sha512-G0wRwjBUeRcSB7QkwqTKHgIzt08jW0Y9y6M++Ldu2wI9gkL3PM37x9Uk4KcUoQbDINaXf11Mcga9T7fTF0WN4g==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@cagov/wordpress-to-github/-/wordpress-to-github-0.1.0.tgz",
+      "integrity": "sha512-rmJfGYSC97VMBBVOKBEv/SY4PCDGyIAqapq1I/+dI9Le3LyR8w3xxWjeh7i9QIDyT+XqYQ32H38wpSXjQQGHuQ==",
       "dependencies": {
         "fetch-retry": "^4.1.1",
         "github-api": "^3.4.0",
@@ -1481,9 +1481,9 @@
       }
     },
     "@cagov/wordpress-to-github": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@cagov/wordpress-to-github/-/wordpress-to-github-0.0.1.tgz",
-      "integrity": "sha512-G0wRwjBUeRcSB7QkwqTKHgIzt08jW0Y9y6M++Ldu2wI9gkL3PM37x9Uk4KcUoQbDINaXf11Mcga9T7fTF0WN4g==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@cagov/wordpress-to-github/-/wordpress-to-github-0.1.0.tgz",
+      "integrity": "sha512-rmJfGYSC97VMBBVOKBEv/SY4PCDGyIAqapq1I/+dI9Le3LyR8w3xxWjeh7i9QIDyT+XqYQ32H38wpSXjQQGHuQ==",
       "requires": {
         "fetch-retry": "^4.1.1",
         "github-api": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "prettier": "^2.4.1"
   },
   "dependencies": {
-    "@cagov/wordpress-to-github": "^0.0.1"
+    "@cagov/wordpress-to-github": "^0.1.0"
   }
 }


### PR DESCRIPTION
This version of the plugin supports the retrieval of new endpoints listed in the destination repos config file.

This has been tested in the development branch of this plugin, deployed to a separate Azure Function instance and writing to the staging branch of the headless cannabis repository

Verified functionality: publishing flows still work as expected and the new endpoints are retrieved and published as desired