### PR TITLE
use new pantheon

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ https://github.com/cagov/cannabis.ca.gov
 
 ## Referenced WordPress instances
 
-- https://cannabis.ca.gov/wp-admin/
-- https://live-cagov-dcc.pantheonsite.io/wp-admin/
-- https://dev-cagov-dcc.pantheonsite.io/wp-admin/
+- https://live-cannabis-ca-gov.pantheonsite.io/wp-admin/
 
 ## WordPress notification config target
 

--- a/WordpressSync/endpoints.json
+++ b/WordpressSync/endpoints.json
@@ -10,10 +10,10 @@
         "name": "headless.cannabis.ca.gov",
         "description": "",
         "enabled": true,
-        "enabledLocal": true,
+        "enabledLocal": false,
         "ReportingChannel_Slack": "C02G6PETB9B",
         "WordPressSource": {
-          "url": "https://live-cagov-dcc.pantheonsite.io",
+          "url": "https://live-cannabis-ca-gov.pantheonsite.io",
           "tags_exclude": []
         },
         "GitHubTarget": {


### PR DESCRIPTION
This uses the new live instance of the new pantheon WordPress cannabis site

Tested this locally, runs without error