### PR TITLE
Add `await` on fetch request

### DIFF
--- a/WordpressSync/endpoints.json
+++ b/WordpressSync/endpoints.json
@@ -7,53 +7,19 @@
   "data": {
     "projects": [
       {
-        "name": "headless.cannabis.ca.gov",
-        "description": "",
-        "enabled": true,
-        "enabledLocal": false,
-        "ReportingChannel_Slack": "C02G6PETB9B",
-        "WordPressSource": {
-          "url": "https://api.cannabis.ca.gov",
-          "tags_exclude": []
-        },
-        "GitHubTarget": {
-          "Owner": "cagov",
-          "Repo": "cannabis.ca.gov",
-          "Branch": "main",
-          "ConfigPath": "odi-publishing/wordpress-to-github.config.json"
-        }
-      },
-      {
-        "name": "staging.cannabis.ca.gov",
-        "description": "",
-        "enabled": true,
-        "enabledLocal": false,
-        "ReportingChannel_Slack": "C02G6PETB9B",
-        "WordPressSource": {
-          "url": "https://api.cannabis.ca.gov",
-          "tags_exclude": []
-        },
-        "GitHubTarget": {
-          "Owner": "cagov",
-          "Repo": "cannabis.ca.gov",
-          "Branch": "staging",
-          "ConfigPath": "odi-publishing/wordpress-to-github.config.json"
-        }
-      },
-      {
-        "name": "test.cannabis.ca.gov",
+        "name": "development.cannabis.ca.gov",
         "description": "",
         "enabled": true,
         "enabledLocal": true,
         "ReportingChannel_Slack": "C02G6PETB9B",
         "WordPressSource": {
-          "url": "https://test-cannabis-ca-gov.pantheonsite.io",
+          "url": "https://dev-cannabis-ca-gov.pantheonsite.io",
           "tags_exclude": []
         },
         "GitHubTarget": {
           "Owner": "cagov",
           "Repo": "cannabis.ca.gov",
-          "Branch": "test",
+          "Branch": "development",
           "ConfigPath": "odi-publishing/wordpress-to-github.config.json"
         }
       }

--- a/wordpress-to-github-0.3.1-draft/github-tree-push/LICENSE
+++ b/wordpress-to-github-0.3.1-draft/github-tree-push/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Office of Digital Innovation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/wordpress-to-github-0.3.1-draft/github-tree-push/README.md
+++ b/wordpress-to-github-0.3.1-draft/github-tree-push/README.md
@@ -1,0 +1,314 @@
+# GitHub Tree Push
+
+A module for pushing content to GitHub. You can use it for complicated folder structure updates or just a single file.
+
+## Features
+
+- Multiple file updates can be combined into a single commit
+- GitHub compatible file hashing reduces the I/O required to push content
+- Implicit file renaming
+- Multi-threaded file uploads
+- Pull requests can created from the commit
+- Pull request auto-approval that waits for checks to finish before approving
+- Add labels/assignees/reviewers to pull requests
+- Auto retry for common connection errors
+- Fully authenticated and conditional requests conserves rate-limit
+- Huge tree support splits large trees while still maintaining a single commit
+- Asynchronous input file download support
+
+## Why use this?
+
+Most people who use GitHub's API use separate file requests to push their content to GitHub. They expect GitHub to handle all the file compare work. That's fine for small, infrequent updates.
+
+But it can be slow if you're updating more complex collections of files. Sending separate files in separate commits can create conflicts as the files are not updated transactionally.
+
+Placing multiple file operations in single commit:
+
+- Manages changes better
+- Handles renames properly
+- Prevents conflicts
+- Connects duplicate files
+- Makes updates transactional
+- Reduces connection overhead
+
+See [Trees explained](#trees-explained) to find out how this module uses trees.
+
+## Sample Usage
+
+### Prerequisites
+
+```js
+const { GitHubTreePush } = require("@cagov/github-tree-push"); //treePush Class
+const token = process.env["GITHUB_TOKEN"]; //Keep your GitHub token safe
+```
+
+### Setting up a tree
+
+Declare your GitHub target (`owner`/`repo`/`base`/`path`) in each tree instance you create. Find detailed options in [treePush options](#treepush-options).
+
+```js
+let tree1 = new GitHubTreePush(token, {
+  owner: "my-github-owner",
+  repo: "my-github-repository",
+  base: "my-github-branch",
+  path: "my-path-inside-repository"
+});
+```
+
+### Adding files to a tree
+
+Fill your tree with file names and data. Data is not transmitted until you push the tree with `treePush`.
+
+```js
+tree1.syncFile("Root File.txt", "Root File Data"); //Strings
+let binaryData = Buffer.from("My Buffer Text 1");
+tree1.syncFile("Root Buffer.txt", binaryData); //Or binary Data
+tree1.syncFile("Parent Folder/Nester Folder/fileAB1.txt", "Path File Data"); //Paths
+```
+
+### Sending the content to GitHub
+
+One method performs the work once the tree is set up.
+
+```js
+await tree1.treePush();
+```
+
+### Getting info on the last push
+
+You can get information about the last push operation using `lastRunStats`. Find details in [lastRunStats Output](#lastRunStats-output).
+
+```js
+console.log(JSON.stringify(tree1.lastRunStats, null, 2));
+```
+
+### Alternate tree setup for pull requests
+
+There are many options for sending your content as a Pull Request. Find detailed options in [Pull request options](#pull-request-options).
+
+```js
+let tree1 = new GitHubTreePush(token, {
+  owner: "cagov",
+  repo: "my-github-target",
+  base: "github-tree-push-branch",
+  path: "github-tree-push-path",
+  deleteOtherFiles: true,
+  contentToBlobBytes: 2000,
+  commit_message: "My Tree Push Commit",
+  pull_request: true,
+  pull_request_options: {
+    draft: false,
+    body: "Pull Request Body",
+    title: "My Auto Merge Title",
+    auto_merge: true
+    auto_merge_delay: 1000,
+    issue_options: {
+      labels: ["Label 1", "Label 2"],
+      assignees: ["assigned_username"]
+    },
+    review_options: {
+      reviewers: ["reviewer_username"]
+    }
+});
+```
+
+## Object methods
+
+These are the most commonly used methods.
+
+### `syncFile(path, content)`
+
+Sets a single file to the tree to be syncronized (updated or added).
+
+#### `syncFile` parameters
+
+| Parameter Name | Type             | Description                                    |
+| :------------- | :--------------- | :--------------------------------------------- |
+| **`path`**     | string           | **Required.** Path to use for publishing file. |
+| **`content`**  | string \| Buffer | **Required.** Content to use for the file.     |
+
+### `syncDownload(path, url)`
+
+Adds a content URL to be downloaded asyronously before the push happens.
+
+#### `syncDownload` parameters
+
+| Parameter Name | Type   | Description                                    |
+| :------------- | :----- | :--------------------------------------------- |
+| **`path`**     | string | **Required.** Path to use for publishing file. |
+| **`url`**      | string | **Required.** URL for the content to download. |
+
+### `removeFile(path)`
+
+Sets a file to be removed.
+
+#### `removeFile` Parameters
+
+| Parameter Name | Type   | Description                               |
+| :------------- | :----- | :---------------------------------------- |
+| **`path`**     | string | **Required.** Path of file to be removed. |
+
+### `doNotRemoveFile(path)`
+
+Sets a file to **not** be removed when `removeOtherFiles:true`.
+
+#### `doNotRemoveFile` parameters
+
+| Parameter Name | Type   | Description                                 |
+| :------------- | :----- | :------------------------------------------ |
+| **`path`**     | string | **Required.** Path of file to be preserved. |
+
+### `treePushDryRun()`
+
+Returns a list of paths that will be changed if this is run.
+
+### `treePush()`
+
+Push all the files added to the tree to the repository.
+
+## Options explained
+
+### `treePush` options
+
+| Property Name              | Type    | Default               | Description                                                                             |
+| :------------------------- | :------ | :-------------------- | :-------------------------------------------------------------------------------------- |
+| **`owner`**                | string  |                       | **Required.** GitHub _owner_ path.                                                      |
+| **`repo`**                 | string  |                       | **Required.** GitHub _repo_ path.                                                       |
+| **`base`**                 | string  |                       | **Required.** The name of the base branch that the head will be merged into (main/etc). |
+| **`path`**                 | string  | `/`                   | Starting path in the repo for changes to start from.                                    |
+| **`deleteOtherFiles`**     | boolean | `false`               | Set as `true` to delete other files in the path when pushing.                           |
+| **`recursive`**            | boolean | `true`                | Set as `true` to compare sub-folders too.                                               |
+| **`contentToBlobBytes`**   | number  | `50000`               | Content bytes allowed in content tree before turning it into a separate blob upload.    |
+| **`commit_message`**       | string  | `"No commit message"` | Name to identify the commit.                                                            |
+| **`pull_request`**         | boolean | `false`               | Set as `true` to use a pull request.                                                    |
+| **`pull_request_options`** | object  | `{}`                  | Options if using a pull request. See [pull request options](#pull-request-options).     |
+
+### Pull request options
+
+Options based on [GitHub pull request docs](https://docs.github.com/en/rest/reference/pulls#create-a-pull-request).
+
+| Property Name               | Type    | Default | Description                                                                                     |
+| :-------------------------- | :------ | :------ | :---------------------------------------------------------------------------------------------- |
+| **`title`**                 | string  |         | The title of the new pull request. (Leave `issue` blank if you use this.)                       |
+| **`issue`**                 | number  |         | Issue number this pull request replaces (Leave `title` blank if you use this.)                  |
+| **`body`**                  | string  |         | The contents describing the pull request.                                                       |
+| **`maintainer_can_modify`** | boolean | `false` | Sets whether maintainers can modify the pull request.                                           |
+| **`draft`**                 | boolean | `false` | Sets whether the pull request is a draft.                                                       |
+| **`review_options`**        | object  | `{}`    | Options for [pull request reviews](#pull-request-review-options).                               |
+| **`issue_options`**         | object  | `{}`    | Options for [pull request issue](#pull-request-issue-options).                                  |
+| **`automatic_merge`**       | boolean | `false` | Set as `true` to merge the pull request after creating it. Will wait for status checks to pass. |
+| **`automatic_merge_delay`** | number  | `0`     | MS to delay after creating before attempting to merge.                                          |
+
+### Pull request review options
+
+Options based on [GitHub review request docs](https://docs.github.com/en/rest/reference/pulls#request-reviewers-for-a-pull-request).
+
+| Property Name   | Type     | Description                                           |
+| :-------------- | :------- | :---------------------------------------------------- |
+| **`milestone`** | number   | The number for the milestone to associate this issue. |
+| **`labels`**    | string[] | Issue labels to apply to the pull request.            |
+| **`assignees`** | string[] | Logins for users to assign to this issue.             |
+
+### Pull request issue options
+
+Options based on [GitHub issue docs](https://docs.github.com/en/rest/reference/issues#update-an-issue).
+
+| Property Name        | Type     | Description                       |
+| :------------------- | :------- | :-------------------------------- |
+| **`reviewers`**      | string[] | Requests an array of user logins. |
+| **`team_reviewers`** | string[] | Requests an array of team slugs.  |
+
+### `lastRunStats` output
+
+When looking at the last run, the following data is available:
+
+| Property Name                       | Type   | Description                                                                    |
+| :---------------------------------- | :----- | :----------------------------------------------------------------------------- |
+| **`Name`**                          | string | Identifies this stat report.                                                   |
+| **`Tree_Operations`**               | number | Number of CRUD operations in the new tree.                                     |
+| **`Content_Converted_To_Blobs`**    | number | Text content that will be uploaded separately (because of duplicates or size). |
+| **`Blobs_Uploaded`**                | number | Number of blobs uploaded to GitHub just now.                                   |
+| **`Text_Content_Uploaded`**         | number | Number of text content strings that were uploaded together in the tree.        |
+| **`Target_Tree_Size`**              | number | The original tree size.                                                        |
+| **`Files_Deleted`**                 | number | Files deleted from GitHub in this tree.                                        |
+| **`Files_Referenced`**              | number | Files where a SHA reference to a blob was added/moved.                         |
+| **`Commit_URL`**                    | string | The GitHub URL for the commit details.                                         |
+| **`Pull_Request_URL`**              | string | The GitHub URL for the pull request details.                                   |
+| **`GitHub_Rate_Limit_Remaining`**   | number | How many more requests are allowed this hour.                                  |
+| **`GitHub_Rate_Limit_Retry_After`** | number | How long to wait before trying again.                                          |
+
+## Trees explained
+
+Trees are an excellent way to communicate changes with GitHub.
+
+### What does a tree look like?
+
+A tree with 2 file updates would look like this.
+
+```js
+{
+  tree: [
+    {
+      path: "file 1.txt",
+      content: "File 1 Content..."
+    },
+    {
+      path: "file 2.txt",
+      content: "File 2 Content..."
+    }
+  ];
+}
+```
+
+The commit includes both updates.
+
+### How renames work
+
+To rename a file, delete the old name and add the new name in the same tree. As long as these operations are in the same tree, GitHub will notice this and consider it a rename. This module keeps track of the hashes so you do not have to send them again if they are the same.
+
+This example renames `original file name.txt` to `new file name.txt`.
+
+```js
+{
+  tree: [
+    {
+      path: "original file name.txt",
+      sha: null
+    },
+    {
+      path: "new file name.txt",
+      sha: "[hash for original file]"
+    }
+  ];
+}
+```
+
+"`sha: null`" lets GitHub know to remove the old file, combined with the original `sha` added to the new location, it will be treated as a rename.
+
+### Support for large file updates
+
+Binary files, large content, and duplicate files are uploaded as new content multi-threaded. Place their unique hashes in the tree (`sha`) instead of the `content`. GitHub stores these "blobs" in the repository disconnected from the folder structure. Submit a tree update that references the hash of the blob to upload the blob. This means large files get committed to the repo transactionally, without conflicts. If a problem occurs in the update, each blob is still stored disconnected waiting for a tree to reference it. You do not have uploaded it again.
+
+Here is a simple tree update that associates already uploaded blobs with files in the commit.
+
+```js
+{
+  tree: [
+    {
+      path: "big file 1.json",
+      sha: "[hash for big file 1]"
+    },
+    {
+      path: "big file 2.json",
+      sha: "[hash for big file 2]"
+    }
+  ];
+}
+```
+
+The tree is very small to transmit. This is because the heavy file work (transferring the binary files in separate threads) happened before the tree was submitted.
+
+Project locations
+
+- [NPM](https://www.npmjs.com/package/@cagov/github-tree-push)
+- [GitHub](https://github.com/cagov/github-tree-push)

--- a/wordpress-to-github-0.3.1-draft/github-tree-push/index.js
+++ b/wordpress-to-github-0.3.1-draft/github-tree-push/index.js
@@ -1,0 +1,1075 @@
+//@ts-check
+const fetch = require("fetch-retry")(require("node-fetch/lib"), {
+  retries: 3,
+  retryDelay: 2000
+});
+
+/** Default title used when one isn't specified for a Pull Request */
+const defaultPullRequestTitle = "Tree Push Pull Request";
+
+/** Default value for contentToBlobBytes */
+const default_contentToBlobBytes = 50000;
+
+const sha1 = require("sha1");
+/*
+ * see https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
+ *
+ * Git generates the SHA by concatenating a header in the form of blob {content.length} {null byte} and the contents of your file
+ *
+ */
+/**
+ * Returns a Github equivalent sha hash for any given content
+ *
+ * @param {string | Buffer} content string or Buffer content to hash
+ * @returns SHA Hash that would be used on Github for the given content
+ */
+
+const gitHubBlobPredictSha = content =>
+  sha1(
+    Buffer.concat([
+      Buffer.from(`blob ${Buffer.byteLength(content)}\0`, "utf8"),
+      Buffer.isBuffer(content) ? content : Buffer.from(content, "utf8")
+    ])
+  );
+
+/**
+ * Halts processing for a set time
+ *
+ * @param {number} ms milliseconds to sleep (1000 = 1s)
+ */
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * @typedef {object} TreePushTreeOptions
+ * @property {string} owner **Required.** GitHub _owner_ path.
+ * @property {string} repo **Required.** GitHub _repo_ path.
+ * @property {string} base **Required.** The name of the base branch that the head will be merged into (main/etc).
+ * @property {string} [path] Starting path in the repo for changes to start from. Defaults to root.
+ * @property {boolean} [removeOtherFiles] `true` to remove other files in the path when pushing.
+ * @property {boolean} [recursive] `true` to compare sub-folders too.  Default `true`.
+ * @property {number} [contentToBlobBytes] Content bytes allowed in content tree before turning it into a separate blob upload. Default 50000.
+ * @property {string} [commit_message] Name to identify the Commit.
+ * @property {boolean} [pull_request] `true` to use a Pull Request.
+ * @property {TreePushCommitPullRequestOptions} [pull_request_options] Options if using a Pull Request. See https://docs.github.com/en/rest/reference/pulls#create-a-pull-request
+ */
+
+/**
+ * @typedef {object} GithubTreeRow
+ * @property {string} path
+ * @property {string} mode usually '100644'
+ * @property {string} type usually 'blob'
+ * @property {string | null} [sha]
+ * @property {string} [content]
+ */
+
+/**
+ * @typedef {object} GithubCommit
+ * @property {string} sha
+ * @property {string} html_url
+ * @property {string} message
+ * @property {{sha:string}[]} [parents]
+ */
+
+/**
+ * @typedef {object} GithubCompareFile
+ * @property {string} filename
+ * @property {string} status
+ */
+
+/**
+ * @typedef {object} GithubCompare
+ * @property {GithubCommit} commit
+ * @property {GithubCompareFile[]} files
+ */
+
+/**
+ * From https://docs.github.com/en/rest/reference/pulls#request-reviewers-for-a-pull-request
+ *
+ * @typedef {object} TreePushCommitPullRequestReviewOptions
+ * @property {string[]} [reviewers] An array of user logins that will be requested.
+ * @property {string[]} [team_reviewers] An array of team slugs that will be requested.
+ */
+
+/**
+ * From https://docs.github.com/en/rest/reference/issues#update-an-issue
+ *
+ * @typedef {object} TreePushCommitPullRequestIssueOptions
+ * @property {number} [milestone] The number of the milestone to associate this issue.
+ * @property {string[]} [labels] Issue labels to apply to the Pull Request.
+ * @property {string[]} [assignees] Logins for Users to assign to this issue.
+ */
+
+/**
+ * From https://docs.github.com/en/rest/reference/pulls#create-a-pull-request
+ *
+ * @typedef {object} TreePushCommitPullRequestOptions
+ * @property {string} [title] The title of the new pull request. (Leave `issue` blank if you use this)
+ * @property {number} [issue] Issue number this pull request replaces (Leave `title` blank if you use this)
+ * @property {string} [body] The contents describing the pull request.
+ * @property {boolean} [maintainer_can_modify] Indicates whether maintainers can modify the pull request.
+ * @property {boolean} [draft] Indicates whether the pull request is a draft.
+ * @property {TreePushCommitPullRequestReviewOptions} [review_options] Options for reviewers.
+ * @property {TreePushCommitPullRequestIssueOptions} [issue_options] Options for issue.
+ * @property {boolean} [automatic_merge] `true` to merge the PR after creating it. Will wait for status checks to pass.
+ * @property {number} [automatic_merge_delay] MS to delay after creating before attempting to merge.
+ */
+
+/**
+ * @typedef {object} TreeFileOperation
+ * @property {TreeFileOperationSync} [sync]
+ * @property {boolean} [remove]
+ */
+
+/**
+ * @typedef {object} TreeFileOperationSync
+ * @property {string} sha
+ * @property {string} [content]
+ * @property {Buffer} [buffer]
+ */
+
+/**
+ * @typedef {object} TreeFileRunStats
+ * @property {string} Name Identifies this stat report.
+ * @property {number} [Tree_Operations] Number of CRUD operations in the new tree.
+ * @property {number} [Content_Converted_To_Blobs] Text content that will be uploaded separately (because of dupes or size).
+ * @property {number} [Blobs_Uploaded] Number of blobs uploaded to GitHub just now.
+ * @property {number} [Text_Content_Uploaded] Number of text content strings that were uploaded together in the tree.
+ * @property {number} [Target_Tree_Size] The original tree size.
+ * @property {number} [Files_Deleted] Files deleted from GitHub in this tree.
+ * @property {number} [Files_Referenced] Files where a SHA reference to a blob was added/moved.
+ * @property {string} [Commit_URL] The GitHub URL for the commit details.
+ * @property {string} [Pull_Request_URL] The GitHub URL for the pull request details.
+ * @property {number} [GitHub_Rate_Limit_Remaining] How many more requests are allowed this hour.
+ * @property {number} [GitHub_Rate_Limit_Retry_After] How long to wait before trying again.
+ */
+
+/**
+ * @typedef {object} FetchOptions
+ * @property {string} [method]
+ * @property {FetchOptionsHeaders} [headers]
+ */
+
+/**
+ * @typedef {object} FetchOptionsHeaders
+ * @property {string} [Authorization]
+ * @property {string} [Content-Type]
+ * @property {string} [User-Agent]
+ * @property {string} [Accept]
+ * @property {string} [If-None-Match]
+ */
+
+/**
+ * Manage a tree for syncing with GitHub
+ */
+class GitHubTreePush {
+  /**
+   * @param {string} token authentication token
+   * @param {TreePushTreeOptions} options describes the target in GitHub
+   */
+  constructor(token, options) {
+    /**
+     * (private) All registered files for the tree operation
+     *
+     * @type {TreePushTreeOptions}
+     */
+    this.options = options;
+
+    /**
+     *  (private) All registered files for the tree operation
+     *
+     * @type {Map<string,TreeFileOperation>}
+     */
+    this.__treeOperations = new Map();
+
+    /**
+     * Stats from the last operation
+     *
+     * @type {TreeFileRunStats}
+     */
+    this.lastRunStats = { Name: "Not run" };
+
+    /**
+     * The last commit compare where there was a change
+     *
+     * @type {GithubCompare | undefined}
+     */
+    this.lastCompare = undefined;
+
+    /**
+     * The last json object returned from the most recent fetch
+     *
+     * @type {*}
+     */
+    this.lastJson = undefined;
+
+    /**
+     * (private) A list of all the shas we know exist in GitHub
+     *
+     * @type {Set<string>}
+     */
+    this.__knownBlobShas = new Set();
+
+    /**
+     * Hiding the token unless explicitly asked for
+     *
+     * @type {function():string}
+     */
+    this.__token = () => token;
+
+    /**
+     * @type {{path:string,url:string}[]}
+     */
+    this.__downloads = [];
+
+    this.options.recursive = this.options.recursive ?? true; //default to true
+
+    this.options.contentToBlobBytes =
+      this.options.contentToBlobBytes ?? default_contentToBlobBytes; //default size
+  }
+
+  __gitAuthheader() {
+    return {
+      Authorization: `Bearer ${this.__token()}`,
+      "Content-Type": "application/json",
+      "User-Agent": "cagov-github-tree-push",
+      Accept: "application/vnd.github.v3+json" //https://docs.github.com/en/rest/overview/resources-in-the-rest-api#current-version
+    };
+  }
+
+  /**
+   *
+   * @param {FetchOptions} [options] Options to override the defaults
+   */
+  __gitDefaultOptions(options) {
+    return {
+      method: "GET",
+      ...options,
+      headers: { ...this.__gitAuthheader(), ...options?.headers }
+    };
+  }
+
+  /**
+   *Common function for creating a PUT option
+   *
+   * @param {*} bodyJSON JSON to PUT
+   * @param {FetchOptions} [options]
+   */
+  __gitPostOptions(bodyJSON, options) {
+    return {
+      ...this.__gitDefaultOptions(options),
+      method: options?.method || "POST",
+      body: JSON.stringify(bodyJSON)
+    };
+  }
+
+  /**
+   * Perform an authenticated GET to an API path
+   *
+   * @param {string} path
+   * @param {FetchOptions} [options]
+   * @param {number[]} [okStatusCodes]
+   */
+  async __getSomeJson(path, options, okStatusCodes) {
+    return this.__fetchJSON(
+      path,
+      this.__gitDefaultOptions(options),
+      okStatusCodes
+    );
+  }
+
+  /**
+   * Perform an authenticated GET to an API path
+   *
+   * @param {string} path
+   * @param {*} body
+   * @param {FetchOptions} [options]
+   * @param {number[]} [okStatusCodes]
+   */
+  async __postSomeJson(path, body, options, okStatusCodes) {
+    return this.__fetchJSON(
+      path,
+      this.__gitPostOptions(body, options),
+      okStatusCodes
+    );
+  }
+
+  /**
+   * fetch a url with options, return a response (Wrapper for fetch)
+   *
+   * @param {string} path
+   * @param {FetchOptions} [options]
+   * @param {number[]} [okStatusCodes]
+   */
+  async __fetchResponse(path, options, okStatusCodes) {
+    const apiURL = path.startsWith("http")
+      ? path
+      : `https://api.github.com/repos/${this.options.owner}/${this.options.repo}${path}`;
+
+    //All these request have required auth
+    if (!options?.headers?.Authorization) {
+      throw new Error("Authorization Header Required");
+    }
+    return fetch(apiURL, options).then(async response => {
+      this.lastFetchResponse = response;
+      this.lastRunStats.GitHub_Rate_Limit_Remaining = Number(
+        this.lastFetchResponse.headers.get("x-ratelimit-remaining")
+      );
+
+      const retryAfter = this.lastFetchResponse.headers.get("Retry-After");
+      if (retryAfter) {
+        this.lastRunStats.GitHub_Rate_Limit_Retry_After = Number(retryAfter);
+      }
+
+      if (!response.ok && !okStatusCodes?.includes(response.status)) {
+        const body = await response.text();
+
+        throw new Error(
+          `${response.status} - ${response.statusText} - ${response.url} - ${body}`
+        );
+      }
+
+      return response;
+    });
+  }
+
+  /**
+   * fetch a url and return json
+   *
+   * @param {string} path
+   * @param {FetchOptions} [options]
+   * @param {number[]} [okStatusCodes]
+   */
+  async __fetchJSON(path, options, okStatusCodes) {
+    const response = await this.__fetchResponse(path, options, okStatusCodes);
+
+    const contentType = response.headers.get("content-type");
+
+    if (!contentType || !contentType.includes("application/json")) {
+      const text = await response.text();
+      if (!text.length) return null;
+
+      throw new Error(
+        `Non-JSON content type - ${contentType}\n\nContent...\n\n${text}`
+      );
+    }
+
+    const json = await response.json();
+
+    this.lastJson = json;
+
+    return json;
+  }
+
+  /**
+   * Get the tree from the remote repository
+   */
+  async __readTree() {
+    const outputPath = this.options.path;
+    const masterBranch = this.options.base;
+
+    let treeUrl = "";
+    if (outputPath) {
+      //Path Tree
+
+      const pathRootTree = outputPath.split("/").slice(0, -1).join("/"); //gets the parent folder to the output path
+      /** @type {GithubTreeRow[]} */
+      const rootTree = await this.__getSomeJson(
+        `/contents/${pathRootTree}?ref=${masterBranch}` //https://docs.github.com/en/rest/reference/repos#contents
+      );
+
+      const referenceTreeRow = rootTree.find(f => f.path === outputPath);
+
+      if (referenceTreeRow?.sha) {
+        treeUrl = referenceTreeRow.sha;
+      }
+    } else {
+      //Root Tree
+      treeUrl = masterBranch;
+    }
+
+    if (treeUrl) {
+      const recursiveOption = this.options.recursive ? "?recursive=true" : "";
+
+      //https://docs.github.com/en/rest/reference/git#get-a-tree
+      //update the referenceTree to match the remote tree
+
+      /** @type {{sha:string,truncated:boolean,tree:GithubTreeRow[]}}} */
+      const treeResult = await this.__getSomeJson(
+        `/git/trees/${treeUrl}${recursiveOption}`
+      );
+      if (treeResult.truncated) {
+        throw new Error("Tree is too big to compare.  Use a sub-folder.");
+      }
+      const referenceTree = treeResult.tree.filter(x => x.type === "blob");
+
+      this.lastRunStats.Target_Tree_Size = referenceTree.length;
+
+      //Add all the known shas to a list
+      referenceTree
+        .map(x => x.sha)
+        .forEach(x => {
+          if (x) {
+            this.__knownBlobShas.add(x);
+          }
+        });
+
+      return referenceTree;
+    } else {
+      //empty tree
+      return [];
+    }
+  }
+
+  /**
+   * returns an update tree that for files in the fileMap that are changed from the referenceTree
+   *
+   * @param {GithubTreeRow[]} existingFilesTree
+   */
+  __deltaTree(existingFilesTree) {
+    const outputPath = this.options.path;
+
+    //process auto deletes
+    if (this.options.removeOtherFiles) {
+      existingFilesTree
+        .map(f => f.path)
+        .filter(path => !this.__treeOperations.has(path))
+        .forEach(path => {
+          this.removeFile(path);
+        });
+    }
+
+    /** @type {GithubTreeRow[]} */
+    const targetTree = [];
+
+    for (const [opPath, operation] of this.__treeOperations) {
+      let existingFile = existingFilesTree.find(x => x.path === opPath);
+
+      //Tree parts...
+      //https://docs.github.com/en/free-pro-team@latest/rest/reference/git#create-a-tree
+      /** @type {GithubTreeRow} */
+      let treeRow = {
+        path: outputPath ? `${outputPath}/${opPath}` : opPath,
+        mode: "100644", //code for tree blob,
+        type: "blob"
+      };
+
+      if (operation.sync) {
+        //Add / Update
+
+        if (existingFile?.sha !== operation.sync.sha) {
+          //Change detected (Add or Update)
+
+          if (
+            operation.sync.content &&
+            !this.__knownBlobShas.has(operation.sync.sha)
+          ) {
+            treeRow.content = operation.sync.content;
+          } else {
+            treeRow.sha = operation.sync.sha;
+          }
+
+          targetTree.push(treeRow);
+        }
+      } else if (existingFile && operation.remove) {
+        //Specific removal request of existing file
+
+        treeRow.sha = null; //will trigger a delete
+
+        targetTree.push(treeRow);
+      }
+    } // looping through __treeOperations
+
+    return targetTree;
+  }
+
+  /**
+   *  Return a commit with all the tree changes
+   *
+   * @param {GithubTreeRow[]} tree from createTreeFromFileMap
+   * @param {string} [commit_message] optional commit message
+   */
+  async __createCommitFromTree(tree, commit_message) {
+    if (!tree.length) {
+      return null;
+    }
+
+    const targetBranch = this.options.base;
+
+    let treeParts = [tree];
+    const totalRows = tree.length;
+
+    console.log(
+      `Total tree size is ${Buffer.byteLength(JSON.stringify(tree))} bytes`
+    );
+
+    this.lastRunStats.Tree_Operations = tree.length;
+
+    //Split the tree into allowable sizes
+    let evalIndex = 0;
+    while (evalIndex < treeParts.length) {
+      if (JSON.stringify(treeParts[evalIndex]).length > 9000000) {
+        let half = Math.ceil(treeParts[evalIndex].length / 2);
+        treeParts.unshift(treeParts[evalIndex].splice(0, half));
+      } else {
+        evalIndex++;
+      }
+    }
+
+    //Grab the starting point for a fresh tree
+    /** @type {{object:{sha:string}}} */
+    const refResult = await this.__getSomeJson(
+      `/git/refs/heads/${targetBranch}`
+    );
+
+    const baseSha = refResult.object.sha;
+
+    //Loop through adding items to the tree
+    let createTreeResult = { sha: baseSha };
+    let rowCount = 0;
+    for (let treePart of treeParts) {
+      rowCount += treePart.length;
+      console.log(`Creating tree - ${rowCount}/${totalRows} items`);
+
+      createTreeResult = await this.__postSomeJson("/git/trees", {
+        tree: treePart,
+        base_tree: createTreeResult.sha
+      });
+    }
+
+    //Create a commit the maps to all the tree changes
+    /** @type {GithubCommit} */
+    const commitResult = await this.__postSomeJson("/git/commits", {
+      parents: [baseSha],
+      tree: createTreeResult.sha,
+      message: commit_message || ""
+    });
+    console.log(`${commitResult.message} - ${commitResult.html_url}`);
+
+    //Add all the new content shas to the list
+    tree
+      .map(x => x.content)
+      .forEach(x => {
+        if (x) {
+          this.lastRunStats.Text_Content_Uploaded =
+            (this.lastRunStats.Text_Content_Uploaded || 0) + 1;
+          this.__knownBlobShas.add(gitHubBlobPredictSha(x));
+        }
+      });
+
+    tree
+      .map(x => x.sha)
+      .filter(x => x === null)
+      .forEach(() => {
+        this.lastRunStats.Files_Deleted =
+          (this.lastRunStats.Files_Deleted || 0) + 1;
+      });
+
+    tree
+      .map(x => x.sha)
+      .filter(x => x)
+      .forEach(() => {
+        this.lastRunStats.Files_Referenced =
+          (this.lastRunStats.Files_Referenced || 0) + 1;
+      });
+
+    this.lastRunStats.Commit_URL = commitResult.html_url;
+
+    return commitResult;
+  }
+
+  /**
+   * Creates a GitHub compare
+   *
+   * @param {GithubCommit} commit
+   * @returns {Promise<GithubCompare | null>}
+   */
+  async __compareCommit(commit) {
+    if (!commit?.parents) {
+      return null;
+    }
+    const baseSha = commit.parents[0].sha;
+    const commitSha = commit.sha;
+
+    //https://docs.github.com/en/rest/reference/repos#compare-two-commits
+    //Compare the proposed commit with the parent
+    const compare = await this.__getSomeJson(
+      `/compare/${baseSha}...${commitSha}`
+    );
+
+    /** @type {*[]} */
+    const commitsArray = compare.commits;
+
+    if (commitsArray.length) {
+      //pull in some common commit info
+      compare.commit = commitsArray[0];
+      compare.commit.message = compare.commit.commit.message;
+    }
+
+    this.lastCompare = compare;
+
+    return compare;
+  }
+
+  /**
+   * Sets a single file to the tree to be syncronized (updated or added).
+   *
+   * @param {string} path Path to use for publishing file
+   * @param {*} content Content to use for the file.
+   */
+  syncFile(path, content) {
+    /** @type {TreeFileOperationSync} */
+    let sync = { sha: "" };
+
+    if (Buffer.isBuffer(content)) {
+      sync.buffer = content;
+      sync.sha = gitHubBlobPredictSha(sync.buffer);
+    } else {
+      sync.content =
+        typeof content === "string"
+          ? content
+          : JSON.stringify(content, null, 2);
+      sync.sha = gitHubBlobPredictSha(sync.content);
+    }
+
+    this.__treeOperations.set(path, { sync });
+  }
+
+  /**
+   * Sets a file to not be removed when `removeOtherFiles:true`.
+   *
+   * @param {string} path path of file to be preserved.
+   */
+  doNotRemoveFile(path) {
+    this.__treeOperations.set(path, { remove: false });
+  }
+
+  /**
+   * Sets a file to removed.
+   *
+   * @param {string} path Path of file to be removed.
+   */
+  removeFile(path) {
+    this.__treeOperations.set(path, { remove: true });
+  }
+
+  /**
+   * Adds a content URL to be downloaded asyronously before the push happens.
+   *
+   * @param {string} path Path to use for publishing file
+   * @param {string} url URL for the content to download.
+   */
+  syncDownload(path, url) {
+    this.__downloads.push({ path, url });
+  }
+
+  /**
+   * Based on the current file map, upload blobs, including duplicate content and large content
+   */
+  async __syncBlobs() {
+    //Turn duplicate content into buffers
+    const fileMapValues = [...this.__treeOperations.values()];
+
+    const blobPromises = [];
+
+    //Push Buffers
+    for (const value of fileMapValues) {
+      if (value.sync) {
+        if (!this.__knownBlobShas.has(value.sync.sha)) {
+          if (value.sync.content) {
+            //If the content is duplicate, or too large, use a buffer
+            if (
+              Buffer.byteLength(value.sync.content, "utf8") >
+              (this.options?.contentToBlobBytes ??
+                fileMapValues.filter(x => x.sync?.sha === value.sync?.sha)
+                  .length > 1) //2 or more found
+            ) {
+              //content converted to blobs
+              this.lastRunStats.Content_Converted_To_Blobs =
+                (this.lastRunStats.Content_Converted_To_Blobs || 0) + 1;
+              value.sync.buffer = Buffer.from(value.sync.content);
+              delete value.sync.content;
+            }
+          }
+
+          //If buffer and the sha is not already confirmed uploaded, check it and upload.
+          if (value.sync.buffer) {
+            blobPromises.push(
+              this.__putBlobInRepo(value.sync.sha, value.sync.buffer)
+            );
+            this.__knownBlobShas.add(value.sync.sha);
+          }
+        }
+      }
+    }
+
+    if (blobPromises.length) {
+      console.log(`Syncing ${blobPromises.length} blobs`);
+      await Promise.all(blobPromises);
+    }
+  }
+
+  /**
+   * Makes sure the blob is in the repo
+   *
+   * @param {string} sha
+   * @param {Buffer} buffer
+   */
+  async __putBlobInRepo(sha, buffer) {
+    return this.__fetchResponse(
+      //https://docs.github.com/en/rest/reference/git#get-a-blob
+      `/git/blobs/${sha}`,
+      this.__gitDefaultOptions({ method: "HEAD" }),
+      [404]
+    ).then(async headResult => {
+      let logNote = "Found...";
+      if (headResult.status === 404) {
+        logNote = "Uploading...";
+
+        //https://docs.github.com/en/rest/reference/git#blobs
+        await this.__postSomeJson("/git/blobs", {
+          content: buffer.toString("base64"),
+          encoding: "base64"
+        });
+
+        this.lastRunStats.Blobs_Uploaded =
+          (this.lastRunStats.Blobs_Uploaded || 0) + 1;
+      }
+
+      //List all the files being uploaded/matched
+      [...this.__treeOperations]
+        .filter(([, value]) => value.sync?.sha === sha)
+        .forEach(([key]) => console.log(logNote + key));
+    });
+  }
+
+  /**
+   * @typedef {object} PrStatus
+   * @property {number} number
+   * @property {boolean} mergeable
+   * @property {string} mergeable_state
+   * @property {string} state
+   * @property {boolean} draft
+   * @property {string} etag
+   * @property {number} status
+   */
+
+  /**
+   * Internal function used for polling Pr Status
+   *
+   * @param {number} prnumber
+   * @param {PrStatus} [originalData]
+   */
+  async __getPrStatus(prnumber, originalData) {
+    const header = originalData?.etag
+      ? {
+          headers: { "If-None-Match": originalData.etag }
+        }
+      : undefined;
+
+    //https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
+    /** @type {PrStatus} */
+    const jsonResult = await this.__getSomeJson(`/pulls/${prnumber}`, header, [
+      304
+    ]);
+
+    const status = this.lastFetchResponse?.status;
+    const etag = this.lastFetchResponse?.headers.get("etag");
+
+    //https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests
+    return /** @type {PrStatus} */ (
+      jsonResult
+        ? {
+            ...jsonResult,
+            status,
+            etag
+          }
+        : { ...originalData, status }
+    );
+  }
+
+  /**
+   * @typedef {object} PrCheckStatus
+   * @property {{status:string,conclusion:string,html_url:string}[]} check_runs
+   * @property {string} etag
+   * @property {number} status
+   */
+
+  /**
+   * Internal function used for polling Pr CHECK Status
+   *
+   * @param {string} commitsha
+   * @param {PrCheckStatus} [originalData]
+   */
+  async __getPrCheckStatus(commitsha, originalData) {
+    const header = originalData?.etag
+      ? {
+          headers: { "If-None-Match": originalData.etag }
+        }
+      : undefined;
+
+    //https://docs.github.com/en/rest/reference/checks#list-check-runs-for-a-git-reference
+    /** @type {PrCheckStatus} */
+    const jsonResult = await this.__getSomeJson(
+      `/commits/${commitsha}/check-runs`,
+      header,
+      [304]
+    );
+
+    const status = this.lastFetchResponse?.status;
+    const etag = this.lastFetchResponse?.headers.get("etag");
+
+    //https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests
+
+    return /** @type {PrCheckStatus} */ (
+      jsonResult
+        ? {
+            ...jsonResult,
+            status,
+            etag
+          }
+        : { ...originalData, status }
+    );
+  }
+
+  /**
+   * async download of any requested urls
+   */
+  async __getDownloads() {
+    if (this.__downloads.length) {
+      const urls = [...new Set(this.__downloads.map(dl => dl.url))];
+
+      console.log(`Downloading ${urls.length} file(s)...\n${urls.join("\n")}`);
+      // console.log(urls);
+      const promises = urls.map(async url => {
+        if (url !== undefined) {
+          return await fetch(url)
+            .then(fetchResponse => {
+              if (fetchResponse.ok) {
+                return fetchResponse.arrayBuffer();
+              } else {
+                throw new Error(
+                  `${fetchResponse.status} - ${fetchResponse.statusText} - ${fetchResponse.url}`
+                );
+              }
+            })
+            .then(blob => ({ url, buffer: Buffer.from(blob) }))
+          }
+        }
+      );
+
+      /** @type {Map<string,Buffer>} */
+      const downloadResults = new Map();
+      (await Promise.all(promises)).forEach(promise =>
+        downloadResults.set(promise.url, promise.buffer)
+      );
+
+      console.log(`${urls.length} download(s) complete.`);
+
+      this.__downloads.forEach(dl => {
+        this.syncFile(dl.path, downloadResults.get(dl.url));
+      });
+    }
+  }
+
+  /**
+   * Returns a list of paths that will be changed if this is run.
+   */
+  async treePushDryRun() {
+    this.lastRunStats = {
+      Name: `treePushDryRun - ${
+        this.options.commit_message || "(No commit message)"
+      }`
+    };
+
+    const referenceTree = await this.__readTree();
+
+    const updatetree = this.__deltaTree(referenceTree);
+
+    return updatetree.map(x => x.path);
+  }
+
+  /**
+   * Push all the files added to the tree to the repository
+   */
+  async treePush() {
+    this.lastRunStats = {
+      Name: `treePush - ${this.options.commit_message || "(No commit message)"}`
+    };
+
+    await this.__getDownloads();
+
+    const referenceTree = await this.__readTree();
+
+    await this.__syncBlobs();
+
+    const updatetree = this.__deltaTree(referenceTree);
+
+    const commit = await this.__createCommitFromTree(
+      updatetree,
+      this.options.commit_message
+    );
+
+    if (!commit) {
+      console.log(`${this.lastRunStats.Name} - No Changes.`);
+    } else {
+      const compare = await this.__compareCommit(commit);
+
+      if (compare?.files.length) {
+        //Changes to apply
+
+        if (this.options.pull_request) {
+          //Pull Request Mode
+          const newBranchName = `${this.options.base}-${commit.sha}`;
+
+          const pull_request_options = { ...this.options.pull_request_options };
+
+          //https://docs.github.com/en/rest/reference/pulls#request-reviewers-for-a-pull-request
+          const review_options = pull_request_options.review_options;
+          delete pull_request_options.review_options;
+
+          //https://docs.github.com/en/rest/reference/issues#update-an-issue
+          const issue_options = pull_request_options.issue_options;
+          delete pull_request_options.issue_options;
+
+          const auto_merge = pull_request_options.automatic_merge;
+          delete pull_request_options.automatic_merge;
+          const auto_merge_delay = pull_request_options.automatic_merge_delay;
+          delete pull_request_options.automatic_merge_delay;
+
+          //https://docs.github.com/en/rest/reference/git#create-a-reference
+          await this.__postSomeJson("/git/refs", {
+            sha: commit.sha,
+            ref: `refs/heads/${newBranchName}`
+          });
+
+          const prOptions = {
+            head: newBranchName,
+            base: this.options.base,
+            ...pull_request_options
+          };
+
+          if (!prOptions.title && !prOptions.issue) {
+            prOptions.title = defaultPullRequestTitle;
+          }
+
+          //https://docs.github.com/en/rest/reference/pulls#create-a-pull-request
+          /** @type {{number:number,head:{ref:string},html_url:string}} */
+          const prResult = await this.__postSomeJson("/pulls", prOptions);
+
+          if (issue_options) {
+            //https://docs.github.com/en/rest/reference/issues#update-an-issue
+            await this.__postSomeJson(
+              `/issues/${prResult.number}`,
+              issue_options,
+              {
+                method: "PATCH"
+              }
+            );
+          }
+
+          if (review_options) {
+            //https://docs.github.com/en/rest/reference/pulls#request-reviewers-for-a-pull-request
+            await this.__postSomeJson(
+              `/pulls/${prResult.number}/requested_reviewers`,
+              review_options
+            );
+          }
+
+          if (auto_merge) {
+            if (auto_merge_delay) {
+              console.log(`Waiting ${auto_merge_delay}ms before merging PR...`);
+              await sleep(auto_merge_delay);
+            }
+            let checkStatus = await this.__getPrCheckStatus(commit.sha);
+            let prStatus = await this.__getPrStatus(prResult.number);
+
+            let waitAttemps = 0;
+
+            while (
+              prStatus.mergeable_state === "unknown" ||
+              (["blocked", "unstable"].includes(prStatus.mergeable_state) &&
+                checkStatus.check_runs.some(x => x.status !== "completed"))
+            ) {
+              // If the mergable state is unknown, or it is blocked with incomplete checks
+              // Unknown mergable state happens for a few seconds after the PR is created
+              // "unstable" is when there are no blocking checks, but checks are running.  "blocked" is when blocking checks are running.
+
+              console.log(
+                `Waiting for merge, checks = ${checkStatus.check_runs.length}. mergable = ${prStatus.mergeable}, prstatus = ${prStatus.status}, checkstatus = ${checkStatus.status}, mergeable_state = ${prStatus.mergeable_state}`
+              );
+
+              await sleep(1000);
+
+              prStatus = await this.__getPrStatus(prResult.number, prStatus);
+
+              checkStatus = await this.__getPrCheckStatus(
+                commit.sha,
+                checkStatus
+              );
+
+              const failedCheck = checkStatus.check_runs.find(
+                x => x.conclusion === "failure"
+              );
+
+              if (failedCheck) {
+                throw new Error(
+                  `Auto Merge Check run failed - ${failedCheck.html_url}`
+                );
+              }
+
+              waitAttemps++;
+              if (waitAttemps > 100) {
+                throw new Error(
+                  `Auto Merge waited too long - ${prResult.html_url}`
+                );
+              }
+            }
+
+            console.log(
+              `Done Waiting, checks = ${checkStatus.check_runs.length}. mergable = ${prStatus.mergeable}, prstatus = ${prStatus.status}, checkstatus = ${checkStatus.status}, mergeable_state = ${prStatus.mergeable_state}`
+            );
+
+            //https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request
+            await this.__postSomeJson(
+              `/pulls/${prResult.number}/merge`,
+              { merge_method: "squash" },
+              {
+                method: "PUT"
+              }
+            );
+
+            //Check before deleting (In case of auto-delete)
+            const headResult = await this.__fetchResponse(
+              `/git/refs/heads/${prResult.head.ref}`,
+              this.__gitDefaultOptions({ method: "HEAD" }),
+              [404]
+            );
+
+            if (headResult.ok) {
+              //https://docs.github.com/en/rest/reference/git#delete-a-reference
+              await this.__fetchResponse(
+                `/git/refs/heads/${prResult.head.ref}`,
+                this.__gitDefaultOptions({ method: "DELETE" })
+              );
+            }
+          }
+          this.lastRunStats.Pull_Request_URL = prResult.html_url;
+        } else {
+          //Just a simple commit on this branch
+          //https://docs.github.com/en/rest/reference/git#update-a-reference
+          await this.__postSomeJson(
+            `/git/refs/heads/${this.options.base}`,
+            {
+              sha: commit.sha
+            },
+            { method: "PATCH" }
+          );
+        }
+      }
+    }
+
+    return this.lastRunStats;
+  }
+}
+
+module.exports = { GitHubTreePush };

--- a/wordpress-to-github-0.3.1-draft/github-tree-push/package-lock.json
+++ b/wordpress-to-github-0.3.1-draft/github-tree-push/package-lock.json
@@ -1,0 +1,833 @@
+{
+  "name": "cagov-github-tree-push-development",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@es-joy/jsdoccomment": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.14.1.tgz",
+      "integrity": "sha512-yiA5X6BSIv99DIeRl7PTBxqg7Lx81cx+ghbW6UJJxoVAKX4NxSAdZ7DKTXsSILUL4FuHDNb54AylTndLdLm8+w==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.3.0",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "2.0.2"
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
+      "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.2.0",
+        "globals": "^13.9.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
+      "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "comment-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
+      "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "eslint": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.5.0.tgz",
+      "integrity": "sha512-tVGSkgNbOfiHyVte8bCM8OmX+xG9PzVG/B4UCF60zx7j61WIVY/AqJECDgpLD4DbbESD0e174gOg3ZlrX15GDg==",
+      "dev": true,
+      "requires": {
+        "@eslint/eslintrc": "^1.0.5",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.0",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.2.0",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "37.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.4.2.tgz",
+      "integrity": "sha512-hKTIu5m0PxD21ZXdFVFpknEyp9aMvDMzamR+1bkcRHK9MDIYgroRGBQCeHupvcZ5TyGU0EfE+ed0FhLhkbekfQ==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "0.14.1",
+        "comment-parser": "1.3.0",
+        "debug": "^4.3.3",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "^2.0.2",
+        "regextras": "^0.8.0",
+        "semver": "^7.3.5",
+        "spdx-expression-parse": "^3.0.1"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
+      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.2.0.tgz",
+      "integrity": "sha512-oP3utRkynpZWF/F2x/HZJ+AGtnIclaR7z1pYPxy7NYM2fSO6LgK/Rkny8anRSPK/VwEA1eqm2squui0T7ZMOBg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.6.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^3.1.0"
+      }
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "globals": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.20.2"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "jsdoc-type-pratt-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.0.2.tgz",
+      "integrity": "sha512-gXN5CxeaI9WtYQYzpOO/CtTRfZppQlKxXRTIm73JuAX6kOGTQ7iZ0e+YB+b2m7Fk+gTYYxRtE1nqje7H6dqv8w==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
+    },
+    "regextras": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
+      "integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    }
+  }
+}

--- a/wordpress-to-github-0.3.1-draft/github-tree-push/package.json
+++ b/wordpress-to-github-0.3.1-draft/github-tree-push/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "cagov-github-tree-push-development",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cagov/github-tree-push.git"
+  },
+  "bugs": "https://github.com/cagov/github-tree-push/issues",
+  "description": "Development project for github-tree-push",
+  "type": "commonjs",
+  "scripts": {
+    "install_normal": "npm install file:github-tree-push-module",
+    "install_without_symlinks": "npm install $(npm pack file:github-tree-push-module | tail -1)"
+  },
+  "author": {
+    "name": "Carter Medlin",
+    "email": "carter@digital.ca.gov",
+    "url": "https://github.com/carterm"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "eslint": "^8.3.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-jsdoc": "^37.0.3",
+    "eslint-plugin-prettier": "^4.0.0",
+    "prettier": "^2.5.0"
+  }
+}

--- a/wordpress-to-github-0.3.1-draft/index.js
+++ b/wordpress-to-github-0.3.1-draft/index.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { GitHubTreePush, GithubCompare } = require("@cagov/github-tree-push");
+const { GitHubTreePush, GithubCompare } = require("./github-tree-push");
 const {
   ensureStringStartsWith,
   removeExcludedProperties,

--- a/wordpress-to-github-0.3.1-draft/package.json
+++ b/wordpress-to-github-0.3.1-draft/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "fetch-retry": "^4.1.1",
-    "node-fetch": "^2.6.1",
-    "@cagov/github-tree-push": "^0.1.1"
+    "node-fetch": "^2.6.1"
   }
 }


### PR DESCRIPTION
In setting up development pipeline, the diff on media was crashing. To fix and test: disconnected github-tree-push from versioning, temporarily commended out the media downloading script, then reenabled - at which point I saw that the "await" was missing from the fetch request - which could explain some timeout 504 errors we were getting back. (Doesn't seem to be pantheon rate limiting)